### PR TITLE
Fix compiler version in `install.sh`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -40,10 +40,12 @@ case `uname` in
         export DARWIN=0
         GCC_VERSION=`gcc -dumpversion`
         COMPILER_NAME="gcc $GCC_VERSION"
-        if [ "$GCC_VERSION" \> "4.6.0" ] || [ "$GCC_VERSION" = "4.6.0" ] || [ "$GCC_VERSION" = "4.6" ] || [ "$GCC_VERSION" -ge 5 ]; then
+        if [ "${GCC_VERSION%%.*}" -ge 5]; then
            export USE_AVX=yes
-        fi
-        if [ "$GCC_VERSION" \> "4.7.0" ] || [ "$GCC_VERSION" = "4.7.0" ] || [ "$GCC_VERSION" = "4.7" ] || [ "$GCC_VERSION" -ge 5 ]; then
+           export USE_AVX2=yes
+        elif [ "$GCC_VERSION" \> "4.6.0" ] || [ "$GCC_VERSION" = "4.6.0" ] || [ "$GCC_VERSION" = "4.6" ] || [ "$GCC_VERSION" -ge 5 ]; then
+           export USE_AVX=yes
+        elif [ "$GCC_VERSION" \> "4.7.0" ] || [ "$GCC_VERSION" = "4.7.0" ] || [ "$GCC_VERSION" = "4.7" ] || [ "$GCC_VERSION" -ge 5 ]; then
            export USE_AVX2=yes
         fi
         ;;

--- a/install.sh
+++ b/install.sh
@@ -40,13 +40,17 @@ case `uname` in
         export DARWIN=0
         GCC_VERSION=`gcc -dumpversion`
         COMPILER_NAME="gcc $GCC_VERSION"
-        if [ "${GCC_VERSION%%.*}" -ge 5]; then
+        echo "GCC_VERSION: $GCC_VERSION, main version: ${GCC_VERSION%%.*}"
+        if [ "${GCC_VERSION%%.*}" -ge 5 ]; then
+           echo "    version -ge 5"
            export USE_AVX=yes
+           export USE_AVX2=yes
+        elif [ "$GCC_VERSION" \> "4.7.0" ] || [ "$GCC_VERSION" = "4.7.0" ] || [ "$GCC_VERSION" = "4.7" ] || [ "$GCC_VERSION" -ge 5 ]; then
+           echo "    version > 4.7.0"
            export USE_AVX2=yes
         elif [ "$GCC_VERSION" \> "4.6.0" ] || [ "$GCC_VERSION" = "4.6.0" ] || [ "$GCC_VERSION" = "4.6" ] || [ "$GCC_VERSION" -ge 5 ]; then
+           echo "    version > 4.6.0"
            export USE_AVX=yes
-        elif [ "$GCC_VERSION" \> "4.7.0" ] || [ "$GCC_VERSION" = "4.7.0" ] || [ "$GCC_VERSION" = "4.7" ] || [ "$GCC_VERSION" -ge 5 ]; then
-           export USE_AVX2=yes
         fi
         ;;
 esac

--- a/install.sh
+++ b/install.sh
@@ -47,6 +47,7 @@ case `uname` in
            export USE_AVX2=yes
         elif [ "$GCC_VERSION" \> "4.7.0" ] || [ "$GCC_VERSION" = "4.7.0" ] || [ "$GCC_VERSION" = "4.7" ] || [ "$GCC_VERSION" -ge 5 ]; then
            echo "    version > 4.7.0"
+           export USE_AVX=yes
            export USE_AVX2=yes
         elif [ "$GCC_VERSION" \> "4.6.0" ] || [ "$GCC_VERSION" = "4.6.0" ] || [ "$GCC_VERSION" = "4.6" ] || [ "$GCC_VERSION" -ge 5 ]; then
            echo "    version > 4.6.0"

--- a/install.sh
+++ b/install.sh
@@ -40,17 +40,13 @@ case `uname` in
         export DARWIN=0
         GCC_VERSION=`gcc -dumpversion`
         COMPILER_NAME="gcc $GCC_VERSION"
-        echo "GCC_VERSION: $GCC_VERSION, main version: ${GCC_VERSION%%.*}"
         if [ "${GCC_VERSION%%.*}" -ge 5 ]; then
-           echo "    version -ge 5"
            export USE_AVX=yes
            export USE_AVX2=yes
         elif [ "$GCC_VERSION" \> "4.7.0" ] || [ "$GCC_VERSION" = "4.7.0" ] || [ "$GCC_VERSION" = "4.7" ] || [ "$GCC_VERSION" -ge 5 ]; then
-           echo "    version > 4.7.0"
            export USE_AVX=yes
            export USE_AVX2=yes
         elif [ "$GCC_VERSION" \> "4.6.0" ] || [ "$GCC_VERSION" = "4.6.0" ] || [ "$GCC_VERSION" = "4.6" ] || [ "$GCC_VERSION" -ge 5 ]; then
-           echo "    version > 4.6.0"
            export USE_AVX=yes
         fi
         ;;


### PR DESCRIPTION
Unfortunately, I still couldn't build the container after you made a release. I think the problem was that if I didn't use `--docker` with the build command all worked because some other version of `gcc` was used.

Now, after explicitly depending on `gcc >=4.7.0` in the `meta.yaml` file in the build recipe, the package builds with `ioconda-utils build --packages sativa --docker --mulled-test` pointing to my fork. With `gcc` versions from 10 and up, your version tests didn't work as expected, so I updated that.

When you have time, would you please check the PR and, when merged, make another release and I'll update the build scripts.